### PR TITLE
Upgraded vocoder for the tacotron

### DIFF
--- a/learnbot_dsl/components/tacotron/src/util/audio.py
+++ b/learnbot_dsl/components/tacotron/src/util/audio.py
@@ -84,10 +84,14 @@ def _griffin_lim_tensorflow(S):
     S = tf.expand_dims(S, 0)
     S_complex = tf.identity(tf.cast(S, dtype=tf.complex64))
     y = _istft_tensorflow(S_complex)
+    alpha=S_complex ##declared new variable alpha of size 's' for new algorithm fast-griffin-lim
+    alpha_n=0.2 ##another variable for coefficient for new algorithm fast-griffin-lim
     for i in range(hparams.griffin_lim_iters):
-      est = _stft_tensorflow(y)
-      angles = est / tf.cast(tf.maximum(1e-8, tf.abs(est)), tf.complex64)
+
+      #edited code for fast griffin-lim
+      angles = alpha / tf.cast(tf.maximum(1e-8, tf.abs(alpha)), tf.complex64)
       y = _istft_tensorflow(S_complex * angles)
+      alpha=alpha_n*(_stft_tensorflow(y)-alpha)  
     return tf.squeeze(y, 0)
 
 


### PR DESCRIPTION
Fast griffin-lim is a vocoder where the the spectrogram converges at twice rate than the griffin-lim does that means synthesis of a 10sec text takes 5sec which is drastic improvement in performance of the text to speech synthesis speed which has to be included in this type of component