### PR TITLE
Updated hyper parameters for fast Grifin-lim

### DIFF
--- a/learnbot_dsl/components/tacotron/src/hparams.py
+++ b/learnbot_dsl/components/tacotron/src/hparams.py
@@ -36,7 +36,7 @@ hparams = tf.contrib.training.HParams(
 
   # Eval:
   max_iters=200,
-  griffin_lim_iters=60,
+  griffin_lim_iters=30, # Number of iterations used for converging the spectrogram generated in the process of synthesis
   power=1.5,              # Power to raise magnitudes to prior to Griffin-Lim
 )
 


### PR DESCRIPTION
The fast griffin-lim requires half number of iteration corresponding to that of griffin-lim for converging the spectrogram to the same extent